### PR TITLE
Update plugin name to 'build' from 'build-plus'

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = {
 
   createDeployPlugin: function(options) {
     var DeployPlugin = DeployPluginBase.extend({
-      name: options.name,
+      name: 'build',
       defaultConfig: {
         environment: 'production',
         outputPath: 'tmp' + path.sep + 'deploy-dist',


### PR DESCRIPTION
Makes this a dropin replacement for the default build method.